### PR TITLE
Add a clear map button

### DIFF
--- a/cmd/gui/components/gamepad.go
+++ b/cmd/gui/components/gamepad.go
@@ -110,6 +110,16 @@ func (m *GamepadMapView) InfoOverlay(text string) {
 	m.Container.Refresh()
 }
 
+func (m *GamepadMapView) ClearSelectedMap() {
+	for _, number := range m.getGamepadMapColContainers() {
+		c64ButtonsContainer := number.Objects[2].(*fyne.Container)
+
+		for _, button := range c64ButtonsContainer.Objects {
+			button.(*widgets.IconPressSwitch).SetActive(false)
+		}
+	}
+}
+
 func (m *GamepadMapView) ErrorOverlay(text string) {
 	overlayRect := m.Container.Objects[1].(*canvas.Rectangle)
 	overlayRect.Show()

--- a/cmd/gui/views/upload.go
+++ b/cmd/gui/views/upload.go
@@ -21,16 +21,12 @@ import (
 type UploadView struct {
 	Controller *controller.Controller
 
-	LogsView *components.Logs
-
-	ConnectModal     *components.ConnectModal
-	SelectLayerModal *components.SelectMapModal
+	ConnectModal *components.ConnectModal
 
 	GamepadMapView *components.GamepadMapView
 
-	selectedMap int
-
-	UploadButton *widget.Button
+	SelectLayerModal *components.SelectMapModal
+	UploadButton     *widget.Button
 }
 
 //go:embed assets/*
@@ -116,7 +112,6 @@ func NewUploadView(window fyne.Window) (uv *UploadView) {
 
 	selectLayerModal := components.NewSelectMapModal(maps, window.Canvas(), func(layer components.Map) {
 		uv.GamepadMapView.SelectGamepadMap(layer.Number)
-		uv.selectedMap = layer.Number
 	})
 	selectLayerModal.Button.Disable()
 
@@ -127,18 +122,15 @@ func NewUploadView(window fyne.Window) (uv *UploadView) {
 	uploadButton := widget.NewButton("Upload", func() {})
 	uploadButton.Disable()
 
-	logsView := components.NewLogs()
-
 	defer func() {
 		uv.UploadButton.OnTapped = handleUpload(uv)
 	}()
 
 	return &UploadView{
 		ConnectModal:     connectModal,
-		SelectLayerModal: selectLayerModal,
 		GamepadMapView:   gamepad,
-		LogsView:         logsView,
 		UploadButton:     uploadButton,
+		SelectLayerModal: selectLayerModal,
 	}
 }
 
@@ -234,7 +226,7 @@ func handleConnect(uv *UploadView, c *controller.Controller, port string) func()
 		uv.GamepadMapView.InfoOverlay("Downloading gamepad maps...")
 		uv.Download()
 
-		uv.GamepadMapView.SelectGamepadMap(uv.selectedMap)
+		uv.GamepadMapView.SelectGamepadMap(uv.GamepadMapView.SelectedGamepadMap())
 		uv.GamepadMapView.Enable()
 		uv.GamepadMapView.HideOverlay()
 

--- a/cmd/gui/views/upload.go
+++ b/cmd/gui/views/upload.go
@@ -26,6 +26,7 @@ type UploadView struct {
 	GamepadMapView *components.GamepadMapView
 
 	SelectLayerModal *components.SelectMapModal
+	ClearMapButton   *widget.Button
 	UploadButton     *widget.Button
 }
 
@@ -114,6 +115,10 @@ func NewUploadView(window fyne.Window) (uv *UploadView) {
 		uv.GamepadMapView.SelectGamepadMap(layer.Number)
 	})
 	selectLayerModal.Button.Disable()
+
+	clearMapButton := widget.NewButton("Clear Map", func() {
+		uv.GamepadMapView.ClearSelectedMap()
+	})
 
 	gamepad := components.NewGamepadMap(keysIcons)
 	gamepad.InfoOverlay("Please connect the device to start")


### PR DESCRIPTION
The clear map button is next to the select map button.

It is disabled, until a device was connected. It simply calls the ClearSelectedMap method of the GamepadMapView, which sets all C64-Buttons to inactive.

It does not directly upload the empty map.